### PR TITLE
[fix][core] FamilyOperandTypeChecker is not readily composable in seq…

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -429,16 +429,18 @@ public class SqlFunctions {
   /** SQL SUBSTRING(string FROM ... FOR ...) function. */
   public static String substring(String c, int s, int l) {
     int lc = c.length();
-    int e = s + l;
+    long e = (long) s + (long) l;
     if (l < 0) {
       throw RESOURCE.illegalNegativeSubstringLength().ex();
     }
-    if (s > lc || e < 1) {
+    // Prevent overflow in addition
+    if (s > lc || e < 1L) {
       return "";
     }
     final int s0 = Math.max(s - 1, 0);
-    final int e0 = Math.min(e - 1, lc);
-    return c.substring(s0, e0);
+    final long e0 = Math.min(e - 1, (long) lc);
+    // We know that e0 cannot exceed Integer.MAX_VALUE, since it's smaller than lc
+    return c.substring(s0, (int) e0);
   }
 
   /** SQL SUBSTRING(binary FROM ...) function for binary. */

--- a/core/src/main/java/org/apache/calcite/sql/type/CompositeOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/CompositeOperandTypeChecker.java
@@ -312,7 +312,7 @@ public class CompositeOperandTypeChecker implements SqlOperandTypeChecker {
         if (!((SqlSingleOperandTypeChecker) rule).checkSingleOperandType(
             callBinding,
             callBinding.getCall().operand(ord.i),
-            rule.getClass() == FamilyOperandTypeChecker.class ? 0 : ord.i,
+            ord.i,
             throwOnFailure)) {
           if (callBinding.isTypeCoercionEnabled()) {
             return coerceOperands(callBinding, false);
@@ -383,7 +383,17 @@ public class CompositeOperandTypeChecker implements SqlOperandTypeChecker {
     if (!callBinding.isTypeCoercionEnabled()) {
       return false;
     }
+    SqlCallBinding sqlBindingWithoutTypeCoercion = new SqlCallBinding(callBinding.getValidator(), callBinding.getScope(),
+            callBinding.getCall()) {
+      @Override
+      public boolean isTypeCoercionEnabled() {
+        return false;
+      }
+    };
     for (SqlOperandTypeChecker rule : allowedRules) {
+      if (rule.checkOperandTypes(sqlBindingWithoutTypeCoercion, false)) {
+        return true;
+      }
       if (rule instanceof ImplicitCastOperandTypeChecker) {
         ImplicitCastOperandTypeChecker rule1 = (ImplicitCastOperandTypeChecker) rule;
         if (rule1.checkOperandTypesWithoutTypeCoercion(callBinding, false)) {

--- a/core/src/main/java/org/apache/calcite/sql/type/CompositeSingleOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/CompositeSingleOperandTypeChecker.java
@@ -64,7 +64,7 @@ public class CompositeSingleOperandTypeChecker
         getRules();
     if (composition == Composition.SEQUENCE) {
       return rules.get(iFormalOperand).checkSingleOperandType(
-          callBinding, node, 0, throwOnFailure);
+          callBinding, node, iFormalOperand, throwOnFailure);
     }
 
     int typeErrorCount = 0;

--- a/core/src/main/java/org/apache/calcite/sql/type/FamilyOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/FamilyOperandTypeChecker.java
@@ -26,6 +26,7 @@ import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.validate.implicit.TypeCoercion;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.calcite.util.Util;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -35,6 +36,14 @@ import static org.apache.calcite.util.Static.RESOURCE;
 /**
  * Operand type-checking strategy which checks operands for inclusion in type
  * families.
+ *
+ * <p>Subclasses that check a single operand should override
+ * {@link #checkSingleOperandType(SqlCallBinding, SqlNode, int, SqlTypeFamily, boolean)}.
+ *
+ * <p>Subclasses that check multiple operands should override either
+ * {@link #checkSingleOperandType(SqlCallBinding, SqlNode, int, SqlTypeFamily, boolean)},
+ * or *both* {@link #checkOperandTypes(SqlCallBinding, boolean)} and
+ * {@link #checkOperandTypesWithoutTypeCoercion(SqlCallBinding, boolean)}.
  */
 public class FamilyOperandTypeChecker implements SqlSingleOperandTypeChecker,
     ImplicitCastOperandTypeChecker {
@@ -65,37 +74,57 @@ public class FamilyOperandTypeChecker implements SqlSingleOperandTypeChecker,
       SqlNode node,
       int iFormalOperand,
       boolean throwOnFailure) {
-    final SqlTypeFamily family = families.get(iFormalOperand);
-    switch (family) {
-    case ANY:
-      final RelDataType type = SqlTypeUtil.deriveType(callBinding, node);
-      SqlTypeName typeName = type.getSqlTypeName();
-
-      if (typeName == SqlTypeName.CURSOR) {
-        // We do not allow CURSOR operands, even for ANY
-        if (throwOnFailure) {
-          throw callBinding.newValidationSignatureError();
-        }
-        return false;
-      }
-      // fall through
-    case IGNORE:
-      // no need to check
-      return true;
-    default:
-      break;
+    Util.discard(iFormalOperand);
+    if (families.size() != 1) {
+      throw new IllegalStateException(
+          "Cannot use as SqlSingleOperandTypeChecker without exactly one family");
     }
-    if (SqlUtil.isNullLiteral(node, false)) {
+    return checkSingleOperandType(
+        callBinding, node, iFormalOperand, families.get(0), throwOnFailure);
+  }
+
+  /**
+   * Helper function used by {@link #checkSingleOperandType(SqlCallBinding, SqlNode, int, boolean)},
+   * {@link #checkOperandTypesWithoutTypeCoercion(SqlCallBinding, boolean)}, and
+   * {@link #checkOperandTypes(SqlCallBinding, boolean)}.
+   */
+  protected boolean checkSingleOperandType(
+          SqlCallBinding callBinding,
+          SqlNode operand,
+          int iFormalOperand,
+          SqlTypeFamily family,
+          boolean throwOnFailure) {
+    Util.discard(iFormalOperand);
+    switch (family) {
+      case ANY:
+        final RelDataType type = SqlTypeUtil.deriveType(callBinding, operand);
+        SqlTypeName typeName = type.getSqlTypeName();
+
+        if (typeName == SqlTypeName.CURSOR) {
+          // We do not allow CURSOR operands, even for ANY
+          if (throwOnFailure) {
+            throw callBinding.newValidationSignatureError();
+          }
+          return false;
+        }
+        // fall through
+      case IGNORE:
+        // no need to check
+        return true;
+      default:
+        break;
+    }
+    if (SqlUtil.isNullLiteral(operand, false)) {
       if (callBinding.isTypeCoercionEnabled()) {
         return true;
       } else if (throwOnFailure) {
-        throw callBinding.getValidator().newValidationError(node,
+        throw callBinding.getValidator().newValidationError(operand,
             RESOURCE.nullIllegal());
       } else {
         return false;
       }
     }
-    RelDataType type = SqlTypeUtil.deriveType(callBinding, node);
+    RelDataType type = SqlTypeUtil.deriveType(callBinding, operand);
     SqlTypeName typeName = type.getSqlTypeName();
 
     // Pass type checking for operators if it's of type 'ANY'.
@@ -125,6 +154,7 @@ public class FamilyOperandTypeChecker implements SqlSingleOperandTypeChecker,
           callBinding,
           op.e,
           op.i,
+          families.get(op.i),
           false)) {
         // try to coerce type if it is allowed.
         boolean coerced = false;
@@ -143,6 +173,7 @@ public class FamilyOperandTypeChecker implements SqlSingleOperandTypeChecker,
               callBinding,
               op1.e,
               op1.i,
+              families.get(op1.i),
               throwOnFailure)) {
             return false;
           }
@@ -166,6 +197,7 @@ public class FamilyOperandTypeChecker implements SqlSingleOperandTypeChecker,
           callBinding,
           op.e,
           op.i,
+          families.get(op.i),
           throwOnFailure)) {
         return false;
       }

--- a/core/src/main/java/org/apache/calcite/sql/type/IntervalOperandTypeChecker.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/IntervalOperandTypeChecker.java
@@ -37,8 +37,7 @@ public class IntervalOperandTypeChecker implements SqlSingleOperandTypeChecker {
   }
 
   @Override public boolean checkSingleOperandType(SqlCallBinding callBinding,
-      SqlNode node, int iFormalOperand, boolean throwOnFailure) {
-    final SqlNode operand = callBinding.operand(iFormalOperand);
+      SqlNode operand, int iFormalOperand, boolean throwOnFailure) {
     if (operand instanceof SqlIntervalQualifier) {
       final SqlIntervalQualifier interval = (SqlIntervalQualifier) operand;
       if (predicate.test(interval)) {

--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -557,11 +557,12 @@ public abstract class OperandTypes {
             SqlCallBinding callBinding,
             SqlNode node,
             int iFormalOperand,
+            SqlTypeFamily family,
             boolean throwOnFailure) {
           if (!LITERAL.checkSingleOperandType(
               callBinding,
               node,
-              iFormalOperand,
+              0,
               throwOnFailure)) {
             return false;
           }
@@ -570,6 +571,7 @@ public abstract class OperandTypes {
               callBinding,
               node,
               iFormalOperand,
+              family,
               throwOnFailure)) {
             return false;
           }
@@ -766,14 +768,14 @@ public abstract class OperandTypes {
       new FamilyOperandTypeChecker(ImmutableList.of(SqlTypeFamily.ANY),
           i -> false) {
         @Override public boolean checkSingleOperandType(
-            SqlCallBinding callBinding, SqlNode node,
-            int iFormalOperand, boolean throwOnFailure) {
-          if (!super.checkSingleOperandType(callBinding, node, iFormalOperand,
+            SqlCallBinding callBinding, SqlNode operand,
+            int iFormalOperand, SqlTypeFamily family, boolean throwOnFailure) {
+          if (!super.checkSingleOperandType(callBinding, operand, iFormalOperand, family,
               throwOnFailure)) {
             return false;
           }
           final SqlValidatorScope scope = callBinding.getScope();
-          if (!scope.isMeasureRef(node)) {
+          if (!scope.isMeasureRef(operand)) {
             if (throwOnFailure) {
               throw callBinding.newValidationError(
                   RESOURCE.argumentMustBeMeasure(
@@ -863,6 +865,15 @@ public abstract class OperandTypes {
             SqlCallBinding callBinding,
             boolean throwOnFailure) {
           if (!super.checkOperandTypes(callBinding, throwOnFailure)) {
+            return false;
+          }
+          return SAME_SAME.checkOperandTypes(callBinding, throwOnFailure);
+        }
+
+        @Override public boolean checkOperandTypesWithoutTypeCoercion(
+                final SqlCallBinding callBinding,
+                final boolean throwOnFailure) {
+          if (!super.checkOperandTypesWithoutTypeCoercion(callBinding, throwOnFailure)) {
             return false;
           }
           return SAME_SAME.checkOperandTypes(callBinding, throwOnFailure);


### PR DESCRIPTION
…uences

By adjusting handling of iFormalOperand in various checkers.

1) CompositeOperandTypeChecker: always send the proper iFormalOperand; never zero.

2) FamilyOperandTypeChecker: always look at the first (and only) family when being
   used as a SqlSingleOperandTypeChecker via checkSingleOperandType. Continue considering
   all families when used as a SqlOperandTypeChecker via checkOperandTypes.

3) IntervalOperandTypeChecker: use the SqlNode parameter, not the SqlCallBinding,
   to get the node to check. Using the SqlCallBinding violates the contract
   of SqlSingleOperandTypeChecker#checkSingleOperandType.